### PR TITLE
Allow application defined errors

### DIFF
--- a/jsonrpc.h
+++ b/jsonrpc.h
@@ -15,4 +15,4 @@ struct jsonrpc_method_entry_t
 };
 char *jsonrpc_handler(const char *input, size_t input_len, struct jsonrpc_method_entry_t method_table[]);
 
-json_t *jsonrpc_error_object(int code, json_t *data);
+json_t *jsonrpc_error_object(int code, const char* message, json_t *data);

--- a/jsonrpc_server.c
+++ b/jsonrpc_server.c
@@ -26,7 +26,7 @@ static int method_subtract(json_t *json_params, json_t **result)
 	}
 
 	if (rc==-1) {
-		*result = jsonrpc_error_object(JSONRPC_INVALID_PARAMS, json_string(error.text));
+		*result = jsonrpc_error_object(JSONRPC_INVALID_PARAMS, NULL, json_string(error.text));
 		return JSONRPC_INVALID_PARAMS;
 	}
 	


### PR DESCRIPTION
Hi,

I needed to return some application defined errors which your JSON-RPC implementation did not allow (application error code was given as an "Internal error" _parameter_). I changed code and API as well as the example (which, unfortunately, I could not test).

Thanks you for this lib!
